### PR TITLE
Remove dependency from JRE library directory

### DIFF
--- a/build.properties.template
+++ b/build.properties.template
@@ -1,4 +1,3 @@
 # This file is part of Kitodo.ContentServer
 
-jre.dir.lib=/usr/lib/jvm/default-java/jre/lib
 tomcat.dir.lib=/usr/share/tomcat7/lib

--- a/build.xml
+++ b/build.xml
@@ -20,12 +20,10 @@
 
     <!-- normally overridden in build.properties -->
     <property name="build.tomcat.dir.lib" value="${dir.lib}" />
-    <property name="build.jre.dir.lib" value="${dir.lib}" />
 
     <path id="compile.classpath">
         <fileset dir="${dir.lib}" />
         <fileset dir="${build.tomcat.dir.lib}" />
-        <fileset dir="${build.jre.dir.lib}" />
         <pathelement location="${build.servlet.jar}" />
         <pathelement path="${java.class.path}" />
     </path>

--- a/src/de/unigoettingen/sub/commons/contentlib/imagelib/magick/ImageManager.java
+++ b/src/de/unigoettingen/sub/commons/contentlib/imagelib/magick/ImageManager.java
@@ -27,10 +27,7 @@ package de.unigoettingen.sub.commons.contentlib.imagelib.magick;
 
 import java.awt.Color;
 import java.awt.image.RenderedImage;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
+import java.io.*;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.util.HashMap;
@@ -44,8 +41,6 @@ import magick.MagickException;
 import magick.MagickImage;
 
 import org.apache.log4j.Logger;
-
-import com.sun.xml.internal.messaging.saaj.util.ByteInputStream;
 
 import de.unigoettingen.sub.commons.contentlib.exceptions.ImageManagerException;
 import de.unigoettingen.sub.commons.contentlib.exceptions.ImageManipulatorException;
@@ -475,7 +470,7 @@ public class ImageManager {
         // Create RenderedImage from MagickImage
         try {
             byte[] imageBlob = outImage.imageToBlob(imageInfo);
-            InputStream iStream = new ByteInputStream(imageBlob, imageBlob.length);
+            InputStream iStream = new ByteArrayInputStream(imageBlob, 0, imageBlob.length);
             RenderedImage riImage = ImageIO.read(iStream);
             return riImage;
         } catch (IOException e) {


### PR DESCRIPTION
Class `ByteInputStream` from package `com.sun.xml.internal.messaging.saaj.util.` needs JRE libraries to build. Changing to `ByteArrayInputStream` class from `java.io` package remove this dependency.
