### PR TITLE
Add OracleJDK and OpenJDK to travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ addons:
 
 cache:
 
+jdk:
+  - oraclejdk7
+  - openjdk7
+
 env:
 
 script: ant -lib /usr/share/tomcat7/lib all


### PR DESCRIPTION
Without defining a JDK, travis is using his default JDK which could OracleJDK8.