### PR TITLE
Raise version number on master branch

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -12,7 +12,7 @@
     <property name="build.javac.source" value="1.7"/>
 
     <property name="build.dist.name" value="kitodo-contentserver" />
-    <property name="build.dist.version" value="2.1.0" />
+    <property name="build.dist.version" value="3.0.0" />
 
     <property name="dist.dir" value="dist" />
 


### PR DESCRIPTION
To reflect changes needed by master branch development of Kitodo.Production the number of master branch should even be raised to next major version.