### PR TITLE
Remove sudo line as not supported any more

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@
 
 dist: trusty
 
-sudo: required
-
 language: java
 
 jdk:


### PR DESCRIPTION
According to this [blog entry](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration) `sudo` lines are not supported any more on Travis CI runs.